### PR TITLE
Phase 4: Neovim Ecosystem Integrations

### DIFF
--- a/lua/swift/init.lua
+++ b/lua/swift/init.lua
@@ -12,6 +12,11 @@ function M.setup(opts)
   local features = require("swift.features")
   features.load()
 
+  -- Load integrations
+  pcall(function()
+    require("swift.integrations.dap").setup()
+  end)
+
   -- Setup commands
   M.setup_commands()
 
@@ -58,6 +63,16 @@ function M.setup_commands()
       "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
     )
   end, { desc = "Show Swift version info" })
+
+  vim.api.nvim_create_user_command("SwiftTelescopeSchemes", function()
+    local telescope = require("swift.integrations.telescope")
+    telescope.xcode_schemes()
+  end, { desc = "Select Xcode Scheme with Telescope" })
+
+  vim.api.nvim_create_user_command("SwiftTelescopeTargets", function()
+    local telescope = require("swift.integrations.telescope")
+    telescope.swift_targets()
+  end, { desc = "Select Swift Target with Telescope" })
 end
 
 function M.setup_autocmds()

--- a/lua/swift/integrations/dap.lua
+++ b/lua/swift/integrations/dap.lua
@@ -1,0 +1,56 @@
+local M = {}
+
+function M.setup()
+  local ok, dap = pcall(require, "dap")
+  if not ok then
+    return
+  end
+
+  -- Auto-register LLDB adapter if not already registered
+  if not dap.adapters.lldb then
+    -- Try to find lldb-dap or lldb-vscode
+    local command = "/usr/bin/lldb-dap"
+    if vim.fn.executable("lldb-vscode") == 1 then
+      command = "lldb-vscode"
+    elseif vim.fn.executable("lldb-dap") == 1 then
+      command = "lldb-dap"
+    end
+
+    dap.adapters.lldb = {
+      type = "executable",
+      command = command,
+      name = "lldb"
+    }
+  end
+
+  -- Auto-register basic Swift configuration if not present
+  if not dap.configurations.swift then
+    dap.configurations.swift = {
+      {
+        name = "Debug Swift Executable",
+        type = "lldb",
+        request = "launch",
+        program = function()
+          local target_manager = require("swift.features.target_manager")
+          local current = target_manager.get_current_target()
+          local detector = require("swift.features.project_detector")
+          local info = detector.get_project_info()
+          
+          if current and info.root and info.type == "spm" then
+            -- Guess the build path for SPM
+            local path = info.root .. "/.build/debug/" .. current
+            if vim.fn.executable(path) == 1 then
+              return path
+            end
+          end
+          
+          return vim.fn.input("Path to executable: ", vim.fn.getcwd() .. "/", "file")
+        end,
+        cwd = "${workspaceFolder}",
+        stopOnEntry = false,
+      }
+    }
+  end
+end
+
+return M

--- a/lua/swift/integrations/telescope.lua
+++ b/lua/swift/integrations/telescope.lua
@@ -1,0 +1,100 @@
+local M = {}
+
+-- Show a Telescope picker for Xcode schemes
+function M.xcode_schemes()
+  local ok, pickers = pcall(require, "telescope.pickers")
+  if not ok then
+    vim.notify("Telescope is not installed", vim.log.levels.WARN, { title = "swift.nvim" })
+    return
+  end
+
+  local finders = require("telescope.finders")
+  local conf = require("telescope.config").values
+  local actions = require("telescope.actions")
+  local action_state = require("telescope.actions.state")
+
+  local xcode = require("swift.features.xcode")
+  local schemes = xcode.list_schemes()
+
+  if #schemes == 0 then
+    vim.notify("No schemes found", vim.log.levels.INFO, { title = "swift.nvim" })
+    return
+  end
+
+  pickers.new({}, {
+    prompt_title = "Xcode Schemes",
+    finder = finders.new_table({
+      results = schemes
+    }),
+    sorter = conf.generic_sorter({}),
+    attach_mappings = function(prompt_bufnr, map)
+      actions.select_default:replace(function()
+        actions.close(prompt_bufnr)
+        local selection = action_state.get_selected_entry()
+        if selection then
+          xcode.build(selection[1])
+        end
+      end)
+      return true
+    end,
+  }):find()
+end
+
+-- Show a Telescope picker for Swift targets (SPM)
+function M.swift_targets()
+  local ok, pickers = pcall(require, "telescope.pickers")
+  if not ok then
+    vim.notify("Telescope is not installed", vim.log.levels.WARN, { title = "swift.nvim" })
+    return
+  end
+
+  local finders = require("telescope.finders")
+  local conf = require("telescope.config").values
+  local actions = require("telescope.actions")
+  local action_state = require("telescope.actions.state")
+
+  local target_manager = require("swift.features.target_manager")
+  local targets = target_manager.get_targets()
+
+  if #targets == 0 then
+    vim.notify("No targets found", vim.log.levels.INFO, { title = "swift.nvim" })
+    return
+  end
+
+  local display_items = {}
+  for _, target in ipairs(targets) do
+    local icon = target.type == "executable" and "󰘧 " or "󰴋 "
+    table.insert(display_items, {
+      value = target,
+      display = icon .. target.name,
+      ordinal = target.name,
+    })
+  end
+
+  pickers.new({}, {
+    prompt_title = "Swift Targets",
+    finder = finders.new_table({
+      results = display_items,
+      entry_maker = function(entry)
+        return {
+          value = entry.value,
+          display = entry.display,
+          ordinal = entry.ordinal,
+        }
+      end
+    }),
+    sorter = conf.generic_sorter({}),
+    attach_mappings = function(prompt_bufnr, map)
+      actions.select_default:replace(function()
+        actions.close(prompt_bufnr)
+        local selection = action_state.get_selected_entry()
+        if selection then
+          target_manager.set_current_target(selection.value.name)
+        end
+      end)
+      return true
+    end,
+  }):find()
+end
+
+return M


### PR DESCRIPTION
Implements Phase 4 of the swift.nvim 2.0 Roadmap. Adds two new integration modules: **Telescope** (interactive pickers for Xcode schemes and SPM targets via `:SwiftTelescopeSchemes` / `:SwiftTelescopeTargets`) and **nvim-dap** (auto-registers LLDB adapter and Swift debug configs so the user can debug with zero setup).