### PR TITLE
fix(lsp): add timeout to xcrun in find_sourcekit_lsp

### DIFF
--- a/lua/swift/features/lsp.lua
+++ b/lua/swift/features/lsp.lua
@@ -38,7 +38,7 @@ function M.find_sourcekit_lsp()
 
   -- Try Xcode toolchain
   if vim.fn.has("mac") == 1 then
-    local xcrun_path = vim.system({ "xcrun", "--find", "sourcekit-lsp" }, { text = true }):wait().stdout or ""
+    local xcrun_path = vim.system({ "xcrun", "--find", "sourcekit-lsp" }, { text = true, timeout = 3000 }):wait().stdout or ""
     xcrun_path = xcrun_path:gsub("\n", "")
     if xcrun_path ~= "" and vim.fn.executable(xcrun_path) == 1 then
       table.insert(possible_paths, 1, xcrun_path)


### PR DESCRIPTION
Closes #2 — deep audit of all shell calls triggered by `:checkhealth swift`.\n\nThe `xcrun --find sourcekit-lsp` call in `lsp.find_sourcekit_lsp()` had **no timeout**. On macOS, `xcrun` can block for 5–10 seconds when the Xcode Developer Directory cache is cold or when Xcode CLT is being initialized for the first time.\n\nThis call is triggered by `:checkhealth swift` → **LSP section** → `lsp.is_available()` → `find_sourcekit_lsp()`.\n\n**Full audit of all shell calls in checkhealth:**\n| Call chain | Timeout | Safe? |\n|---|---|---|\n| `swift --version` | 5s ✅ | ✅ |\n| `xcrun --find sourcekit-lsp` | **none → now 3s** | ✅ |\n| `swift-format --version` | 5s ✅ | ✅ |\n| `target_manager.get_targets()` | removed in #13 ✅ | ✅ |\n| `swiftly list` | removed in #13 ✅ | ✅ |